### PR TITLE
Websites' deployment link added to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A website that showcases a lot of skills and hard work projects made by the deve
 
 - Major languages (HTML, CSS)
 
+
 ## Live Demo
 
 ![demo](https://user-images.githubusercontent.com/102612396/191850624-8d8c1717-a55a-41ea-a002-bc4126ea133b.JPG)
@@ -22,6 +23,10 @@ A website that showcases a lot of skills and hard work projects made by the deve
 ![Demo](https://user-images.githubusercontent.com/102612396/192741085-d95c8177-5271-4c0d-9fab-cfd37c071fbe.JPG)
 
 
+## Getting Started
+
+### Deployment
+https://ofarouq310.github.io/
 
 
 ## Authors
@@ -34,21 +39,25 @@ A website that showcases a lot of skills and hard work projects made by the deve
 
 - GitHub: [@telanet](https://github.com/telanet)
 
+
 ## 🤝 Contributing
 
 Contributions, issues, and feature requests are welcome!
 
 Feel free to check the [issues page](../../issues/).
 
+
 ## Show your support
 
 Give a ⭐️ if you like this project!
+
 
 ## Acknowledgments
 
 - Hat tip to anyone whose code was used
 - Inspiration
 - etc
+
 
 ## 📝 License
 


### PR DESCRIPTION
The website has been published online also known as "Deployment" using Github pages, with editing the README file to contain a section that includes the website link.